### PR TITLE
Fix: default message when changelog is set to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.3.3+5] - September 19, 2024
+
+* Default message when changelog is set to false
+
 ## [2.3.3+4] - July 23, 2024
 
 * Automated dependency updates

--- a/lib/tag.dart
+++ b/lib/tag.dart
@@ -208,6 +208,8 @@ ${scanner.getChanges(version)}
 [CHANGELOG]: $version
 
 $changes''');
+    }else{
+      changes = 'Release $version';
     }
 
     if (dryRun) {

--- a/lib/tag.dart
+++ b/lib/tag.dart
@@ -208,7 +208,7 @@ ${scanner.getChanges(version)}
 [CHANGELOG]: $version
 
 $changes''');
-    }else{
+    } else {
       changes = 'Release $version';
     }
 
@@ -233,7 +233,7 @@ $changes''');
         body: utf8.encode(
           json.encode(
             {
-              if (changes != null) 'message': changes,
+              'message': changes,
               'object': sha,
               'tag': tagName,
               'type': 'commit',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: 'dart_version_autotag'
 description: 'A package that to scan the pubspec.yaml file and automatically create or update a tag in git for it.'
-version: '2.3.3+4'
+version: '2.3.3+5'
 homepage: 'https://github.com/peiffer-innovations/actions-dart-version-autotag'
 
 environment: 


### PR DESCRIPTION

## Why: 

Message is a required field when creating a tag
https://docs.github.com/en/rest/git/tags?apiVersion=2022-11-28#create-a-tag-object

When changelog is set to false, there's no default message and the Github action fails to create the tags


## What:

Added a default message when changelog is set to false

## Validation

Set changelog=false and trigger the CI action, the action should succeed
