### PR TITLE
Feat: Branch override for tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.3.4] - September 24, 2024
+
+* Ability to specify target branch to tag
+
 ## [2.3.3+5] - September 19, 2024
 
 * Default message when changelog is set to false

--- a/README.md
+++ b/README.md
@@ -140,3 +140,4 @@ jobs:
 | `path`       | The path to the pubspec file to track (default: `.`).                         |
 | `prefix`     | The prefix to place before the version number in the tag (default: `v`).      |
 | `token`      | The GitHub access token to create tags in the repository.                     |
+| `branch`     | The target branch from which the tag will be created.                         |

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ jobs:
 
 | Input        | Description                                                                   |
 |--------------|-------------------------------------------------------------------------------|
+| `branch`     | The target branch from which the tag will be created.                         |
 | `changelog`  | Set to `false` to ignore the changelog description (default `true`).          |
 | `major`      | Set to `false` to prevent creating / updating the major tag (default `true`). |
 | `minor`      | Set to `false` to prevent creating / updating the minor tag (default `true`). |
@@ -140,4 +141,3 @@ jobs:
 | `path`       | The path to the pubspec file to track (default: `.`).                         |
 | `prefix`     | The prefix to place before the version number in the tag (default: `v`).      |
 | `token`      | The GitHub access token to create tags in the repository.                     |
-| `branch`     | The target branch from which the tag will be created.                         |

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,9 @@ name: 'Auto Tag Dart Versions'
 description: 'Automatically create tags when you update your pubspec.yaml version'
 author: 'jpeiffer'
 inputs:
+  branch:
+    description: 'The target branch from which the tag will be created.'
+    required: false
   changelog:
     description: 'Set to false to skip scanning the changelog to apply the message.'
     required: false
@@ -29,9 +32,6 @@ inputs:
   token:
     description: 'The GitHub access token to allow file reading and tag creation.'
     required: true
-  branch:
-    description: 'The target branch from which the tag will be created.'
-    required: false
 
 runs:
   using: 'composite'
@@ -48,4 +48,4 @@ runs:
         set -e
 
         dart pub global activate -sgit https://github.com/peiffer-innovations/actions-dart-version-autotag
-        dart pub global run dart_version_autotag:tag --token ${{ inputs.token }} --path ${{ inputs.path }} --prefix "${{ inputs.prefix }}" --repository ${{ github.repository }} --changelog ${{inputs.changelog}} --major ${{inputs.major}} --minor ${{inputs.minor}} --overwrite ${{inputs.overwrite}} --branch ${{inputs.branch}}
+        dart pub global run dart_version_autotag:tag --token ${{ inputs.token }} --path ${{ inputs.path }} --prefix "${{ inputs.prefix }}" --repository ${{ github.repository }} --changelog ${{inputs.changelog}} --branch "${{inputs.branch}}" --major ${{inputs.major}} --minor ${{inputs.minor}} --overwrite ${{inputs.overwrite}}

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
   token:
     description: 'The GitHub access token to allow file reading and tag creation.'
     required: true
+  branch:
+    description: 'The target branch from which the tag will be created.'
+    required: false
 
 runs:
   using: 'composite'
@@ -45,4 +48,4 @@ runs:
         set -e
 
         dart pub global activate -sgit https://github.com/peiffer-innovations/actions-dart-version-autotag
-        dart pub global run dart_version_autotag:tag --token ${{ inputs.token }} --path ${{ inputs.path }} --prefix "${{ inputs.prefix }}" --repository ${{ github.repository }} --changelog ${{inputs.changelog}} --major ${{inputs.major}} --minor ${{inputs.minor}} --overwrite ${{inputs.overwrite}}
+        dart pub global run dart_version_autotag:tag --token ${{ inputs.token }} --path ${{ inputs.path }} --prefix "${{ inputs.prefix }}" --repository ${{ github.repository }} --changelog ${{inputs.changelog}} --major ${{inputs.major}} --minor ${{inputs.minor}} --overwrite ${{inputs.overwrite}} --branch ${{inputs.branch}}

--- a/lib/tag.dart
+++ b/lib/tag.dart
@@ -113,6 +113,7 @@ Future<void> main(List<String>? args) async {
     'prefix': prefix,
     'slug': slug,
     'version': version,
+    if (branchName != null) 'branch': branchName,
   };
   _logger.info('Options:');
   for (var entry in options.entries) {

--- a/lib/tag.dart
+++ b/lib/tag.dart
@@ -69,7 +69,7 @@ Future<void> main(List<String>? args) async {
   final dryRun = parsed['dry-run'] == true;
   final overwrite = parsed['overwrite']?.toString().toLowerCase() == 'true';
   final prefix = parsed['prefix'];
-  final branchName = parsed['branch'] as String?;
+  var branchName = parsed['branch'] as String? ?? '';
   final pubspec = File('$path/pubspec.yaml');
 
   if (!pubspec.existsSync()) {
@@ -104,6 +104,7 @@ Future<void> main(List<String>? args) async {
   }
 
   final options = {
+    'branch': branchName,
     'changelog': useChangelog,
     'dryRun': dryRun,
     'major': useMajor,
@@ -113,7 +114,6 @@ Future<void> main(List<String>? args) async {
     'prefix': prefix,
     'slug': slug,
     'version': version,
-    if (branchName != null) 'branch': branchName,
   };
   _logger.info('Options:');
   for (var entry in options.entries) {
@@ -125,11 +125,8 @@ Future<void> main(List<String>? args) async {
 
   final tags = await gh.repositories.listTags(slug).toList();
   final repo = await gh.repositories.getRepository(slug);
-
-  final branch = await gh.repositories.getBranch(
-    slug,
-    branchName ?? repo.defaultBranch,
-  );
+  branchName = branchName.isNotEmpty ? branchName : repo.defaultBranch;
+  final branch = await gh.repositories.getBranch(slug, branchName);
   final sha = branch.commit!.sha!;
 
   final tagCreated = await _createTag(

--- a/lib/tag.dart
+++ b/lib/tag.dart
@@ -55,6 +55,10 @@ Future<void> main(List<String>? args) async {
     abbr: 't',
     defaultsTo: Platform.environment['GITHUB_TOKEN'],
   );
+  parser.addOption(
+    'branch',
+    defaultsTo: null,
+  );
 
   final parsed = parser.parse(args ?? []);
   final path = parsed['path'];
@@ -65,6 +69,7 @@ Future<void> main(List<String>? args) async {
   final dryRun = parsed['dry-run'] == true;
   final overwrite = parsed['overwrite']?.toString().toLowerCase() == 'true';
   final prefix = parsed['prefix'];
+  final branchName = parsed['branch'] as String?;
   final pubspec = File('$path/pubspec.yaml');
 
   if (!pubspec.existsSync()) {
@@ -120,7 +125,10 @@ Future<void> main(List<String>? args) async {
   final tags = await gh.repositories.listTags(slug).toList();
   final repo = await gh.repositories.getRepository(slug);
 
-  final branch = await gh.repositories.getBranch(slug, repo.defaultBranch);
+  final branch = await gh.repositories.getBranch(
+    slug,
+    branchName ?? repo.defaultBranch,
+  );
   final sha = branch.commit!.sha!;
 
   final tagCreated = await _createTag(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: 'dart_version_autotag'
 description: 'A package that to scan the pubspec.yaml file and automatically create or update a tag in git for it.'
-version: '2.3.3+5'
+version: '2.3.4'
 homepage: 'https://github.com/peiffer-innovations/actions-dart-version-autotag'
 
 environment: 


### PR DESCRIPTION

## WHY
Currently the script uses the default branch to create a tag. This limits the action to projects where the tag is created from development branches

## What
Allowed the script to receive a specific branch name from which the tag should be created

